### PR TITLE
riscv: add configurable hardware breakpoint ranges and fix hart selection

### DIFF
--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -5244,6 +5244,9 @@ static int riscv013_halt_go(struct target *target)
 
 	if (select_prepped_harts(target) != ERROR_OK)
 		return ERROR_FAIL;
+	if (dm->current_hartid != HART_INDEX_MULTIPLE &&
+			dm013_select_target(target) != ERROR_OK)
+		return ERROR_FAIL;
 
 	LOG_TARGET_DEBUG(target, "halting hart");
 
@@ -5493,6 +5496,10 @@ static int riscv013_step_or_resume_current_hart(struct target *target,
 	riscv_reg_cache_invalidate_all(target);
 
 	dm013_info_t *dm = get_dm(target);
+	if (!dm)
+		return ERROR_FAIL;
+	if (dm013_select_target(target) != ERROR_OK)
+		return ERROR_FAIL;
 	/* Issue the resume command, and then wait for the current hart to resume. */
 	uint32_t dmcontrol = DM_DMCONTROL_DMACTIVE | DM_DMCONTROL_RESUMEREQ;
 	dmcontrol = set_dmcontrol_hartsel(dmcontrol, dm->current_hartid);

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -754,6 +754,12 @@ static void riscv_deinit_target(struct target *target)
 		free(entry);
 	}
 
+	address_range_list_t *addr_entry, *addr_tmp;
+	list_for_each_entry_safe(addr_entry, addr_tmp, &info->force_hw_breakpoint_ranges, list) {
+		list_del(&addr_entry->list);
+		free(addr_entry);
+	}
+
 	free(target->arch_info);
 
 	target->arch_info = NULL;
@@ -1604,10 +1610,31 @@ int riscv_read_by_any_size(struct target *target, target_addr_t address, uint32_
 	return ERROR_FAIL;
 }
 
+static bool riscv_should_force_hw_breakpoint(struct target *target, target_addr_t address)
+{
+	RISCV_INFO(r);
+	address_range_list_t *range;
+
+	list_for_each_entry(range, &r->force_hw_breakpoint_ranges, list) {
+		if (address >= range->start && address < range->end)
+			return true;
+	}
+
+	return false;
+}
+
 static int riscv_add_breakpoint(struct target *target, struct breakpoint *breakpoint)
 {
 	LOG_TARGET_DEBUG(target, "@0x%" TARGET_PRIxADDR, breakpoint->address);
 	assert(breakpoint);
+	if (breakpoint->type == BKPT_SOFT &&
+			riscv_should_force_hw_breakpoint(target, breakpoint->address)) {
+		LOG_TARGET_DEBUG(target,
+			"Converting configured software breakpoint BPID %" PRIu32
+			" at 0x%" TARGET_PRIxADDR " to hardware",
+			breakpoint->unique_id, breakpoint->address);
+		breakpoint->type = BKPT_HARD;
+	}
 	if (breakpoint->type == BKPT_SOFT) {
 		/** @todo check RVC for size/alignment */
 		if (!(breakpoint->length == 4 || breakpoint->length == 2)) {
@@ -1702,6 +1729,9 @@ static int riscv_remove_breakpoint(struct target *target,
 		}
 
 	} else if (breakpoint->type == BKPT_HARD) {
+		LOG_TARGET_DEBUG(target,
+			"Removing hardware breakpoint BPID %" PRIu32 " at 0x%" TARGET_PRIxADDR,
+			breakpoint->unique_id, breakpoint->address);
 		struct trigger trigger;
 		trigger_from_breakpoint(&trigger, breakpoint);
 		int result = remove_trigger(target, trigger.unique_id);
@@ -4369,6 +4399,59 @@ COMMAND_HANDLER(riscv_set_mem_access)
 	return ERROR_OK;
 }
 
+COMMAND_HANDLER(riscv_force_hw_breakpoint_range)
+{
+	struct target *target = get_current_target(CMD_CTX);
+	RISCV_INFO(r);
+
+	if (CMD_ARGC == 0) {
+		address_range_list_t *range;
+		const char *separator = "";
+
+		list_for_each_entry(range, &r->force_hw_breakpoint_ranges, list) {
+			command_print_sameline(CMD, "%s0x%" TARGET_PRIxADDR "-0x%" TARGET_PRIxADDR,
+					separator, range->start, range->end);
+			separator = " ";
+		}
+		command_print_sameline(CMD, "\n");
+		return ERROR_OK;
+	}
+
+	if (CMD_ARGC == 1 && !strcmp(CMD_ARGV[0], "clear")) {
+		address_range_list_t *range, *tmp;
+
+		list_for_each_entry_safe(range, tmp, &r->force_hw_breakpoint_ranges, list) {
+			list_del(&range->list);
+			free(range);
+		}
+		return ERROR_OK;
+	}
+
+	if (CMD_ARGC != 2)
+		return ERROR_COMMAND_SYNTAX_ERROR;
+
+	target_addr_t start;
+	target_addr_t end;
+	COMMAND_PARSE_ADDRESS(CMD_ARGV[0], start);
+	COMMAND_PARSE_ADDRESS(CMD_ARGV[1], end);
+
+	if (end <= start) {
+		LOG_TARGET_ERROR(target,
+			"Invalid force_hw_breakpoint_range: end must be greater than start.");
+		return ERROR_COMMAND_ARGUMENT_INVALID;
+	}
+
+	address_range_list_t *range = calloc(1, sizeof(*range));
+	if (!range) {
+		LOG_TARGET_ERROR(target, "Out of memory while adding force_hw_breakpoint_range.");
+		return ERROR_FAIL;
+	}
+
+	range->start = start;
+	range->end = end;
+	list_add_tail(&range->list, &r->force_hw_breakpoint_ranges);
+	return ERROR_OK;
+}
 
 static bool parse_csr_address(const char *reg_address_str, unsigned int *reg_addr)
 {
@@ -5625,6 +5708,14 @@ static const struct command_registration riscv_exec_command_handlers[] = {
 			"of priority. Method can be one of: 'progbuf', 'sysbus' or 'abstract'."
 	},
 	{
+		.name = "force_hw_breakpoint_range",
+		.handler = riscv_force_hw_breakpoint_range,
+		.mode = COMMAND_ANY,
+		.usage = "[clear | start end]",
+		.help = "Configure address ranges where software breakpoints are converted "
+			"to hardware breakpoints. Ranges are half-open: start <= address < end."
+	},
+	{
 		.name = "expose_csrs",
 		.handler = riscv_set_expose_csrs,
 		.mode = COMMAND_CONFIG,
@@ -5967,6 +6058,7 @@ static void riscv_info_init(struct target *target, struct riscv_info *r)
 	INIT_LIST_HEAD(&r->expose_csr);
 	INIT_LIST_HEAD(&r->expose_custom);
 	INIT_LIST_HEAD(&r->hide_csr);
+	INIT_LIST_HEAD(&r->force_hw_breakpoint_ranges);
 
 	r->vsew64_supported = YNM_MAYBE;
 

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -122,6 +122,12 @@ typedef struct {
 	char *name;
 } range_list_t;
 
+typedef struct {
+	struct list_head list;
+	target_addr_t start;
+	target_addr_t end;
+} address_range_list_t;
+
 #define DTM_DTMCS_VERSION_UNKNOWN ((unsigned int)-1)
 #define RISCV_TINFO_VERSION_UNKNOWN (-1)
 
@@ -349,6 +355,12 @@ struct riscv_info {
 	/* The list of registers to mark as "hidden". Hidden registers are available
 	 * but do not appear in gdb targets description or reg command output. */
 	struct list_head hide_csr;
+
+	/* Address ranges where software breakpoints must be implemented with
+	 * hardware triggers. This is useful for XIP flash regions that cannot be
+	 * patched safely at run time.
+	 */
+	struct list_head force_hw_breakpoint_ranges;
 
 	riscv_sample_config_t sample_config;
 	struct riscv_sample_buf sample_buf;


### PR DESCRIPTION
## Summary

Improve HPMicro dual-core RISC-V debugging by fixing hart selection and adding an opt-in address range policy to force hardware breakpoints.

## Motivation

Single-core debugging can usually use software breakpoints without issue. The main problem happens when Core0 and Core1 are debugged at the same time through separate GDB/OpenOCD sessions.

During `step`/`next`, GDB may insert temporary software breakpoints. With two active debug sessions sharing the same executable address space, both sessions may insert, remove, or restore software breakpoints independently. This can make breakpoint state inconsistent and cause both sessions to fail single-step operation reliably.

For selected XIP/code regions, converting software breakpoints to hardware breakpoints avoids instruction patching in the shared code region and makes dual-core debugging much more stable.

## Changes

- Reselect the target hart before halt/resume/step operations.
- Add:

```text
target riscv force_hw_breakpoint_range start end
target riscv force_hw_breakpoint_range clear
target riscv force_hw_breakpoint_range
````

Configured ranges are half-open:

```text
start <= address < end
```

Software breakpoints inside configured ranges are converted to hardware breakpoints.

Example:

```text
target riscv force_hw_breakpoint_range 0x80000000 0x81000000
```

## Validation

Tested with two simultaneous debug sessions on an HPMicro dual-core RISC-V target.

Verified:

* Core0/Core1 simultaneous debugging.
* Repeated single-step on both cores.
* Software breakpoints in the configured range are converted to hardware breakpoints.
* Temporary hardware breakpoints are removed correctly.
* Default behavior is unchanged without configured ranges.